### PR TITLE
Use recv in naive distributer

### DIFF
--- a/include/dynampi/impl/hierarchical_distributor.hpp
+++ b/include/dynampi/impl/hierarchical_distributor.hpp
@@ -26,6 +26,7 @@ template <typename TaskT, typename ResultT, typename... Options>
 class HierarchicalMPIWorkDistributor : public BaseMPIWorkDistributor<TaskT, ResultT, Options...> {
   using Base = BaseMPIWorkDistributor<TaskT, ResultT, Options...>;
 
+ public:
   struct Config {
     MPI_Comm comm = MPI_COMM_WORLD;
     int manager_rank = 0;

--- a/include/dynampi/impl/naive_distributor.hpp
+++ b/include/dynampi/impl/naive_distributor.hpp
@@ -104,7 +104,9 @@ class NaiveMPIWorkDistributor {
   void run_worker() {
     assert(_communicator.rank() != _config.manager_rank && "Worker cannot run on the manager rank");
     using task_type = MPI_Type<TaskT>;
-    _communicator.send(nullptr, _config.manager_rank, Tag::REQUEST);
+    // Send REQUEST as 0 elements of ResultT so manager can recv_any(ResultT&) for both REQUEST and
+    // RESULT
+    _communicator.template send_empty<ResultT>(_config.manager_rank, Tag::REQUEST);
     while (true) {
       MPI_Status status = _communicator.probe();
       if (status.MPI_TAG == Tag::DONE) {
@@ -269,9 +271,8 @@ class NaiveMPIWorkDistributor {
     MPI_Status status;
 
     if (_config.use_immediate_recv) {
-      // Immediate receive mode: use recv_any with predetermined buffer size
-      // For REQUEST messages (empty), we can receive with a null buffer
-      // For RESULT messages, we use the predetermined buffer size
+      // Immediate receive mode: REQUEST and RESULT both use type ResultT (REQUEST = 0 elements).
+      // recv_any(buffer) receives into the same buffer type for both.
       if constexpr (result_type::resize_required) {
         ResultT buffer;
         result_type::resize(buffer, _config.max_result_size);
@@ -312,7 +313,7 @@ class NaiveMPIWorkDistributor {
         process_result_message(status, std::move(buffer), count);
       } else {
         assert(status.MPI_TAG == Tag::REQUEST && "Unexpected tag received in worker");
-        _communicator.recv_empty_message(status.MPI_SOURCE, Tag::REQUEST);
+        _communicator.recv_empty<ResultT>(status.MPI_SOURCE, Tag::REQUEST);
       }
     }
     _free_worker_indices.push(status.MPI_SOURCE);

--- a/include/dynampi/impl/naive_distributor.hpp
+++ b/include/dynampi/impl/naive_distributor.hpp
@@ -244,6 +244,22 @@ class NaiveMPIWorkDistributor {
 
   int worker_for_idx(int idx) const { return (idx < _config.manager_rank) ? idx : (idx + 1); }
 
+  void process_result_message(const MPI_Status& status, ResultT&& result, int count) {
+    using result_type = MPI_Type<ResultT>;
+    int worker_idx = status.MPI_SOURCE - (status.MPI_SOURCE > _config.manager_rank);
+    int64_t task_idx = _worker_current_task_indices[worker_idx];
+    _worker_current_task_indices[worker_idx] = -1;
+    assert(task_idx >= 0 && "Task index should be valid");
+    if (static_cast<uint64_t>(task_idx) >= _results.size()) {
+      _results.resize(task_idx + 1);
+    }
+    if constexpr (result_type::resize_required) {
+      result_type::resize(_results[task_idx], count);
+    }
+    _results[task_idx] = std::move(result);
+    _results_received++;
+  }
+
   void receive_from_any_worker() {
     assert(_communicator.rank() == _config.manager_rank &&
            "Only the manager can receive results and send tasks");
@@ -262,86 +278,38 @@ class NaiveMPIWorkDistributor {
         status = _communicator.recv_any(buffer);
 
         if (status.MPI_TAG == Tag::RESULT) {
-          int64_t task_idx =
-              _worker_current_task_indices[status.MPI_SOURCE -
-                                           (status.MPI_SOURCE > _config.manager_rank)];
-          _worker_current_task_indices[status.MPI_SOURCE -
-                                       (status.MPI_SOURCE > _config.manager_rank)] = -1;
-          assert(task_idx >= 0 && "Task index should be valid");
-          if (static_cast<uint64_t>(task_idx) >= _results.size()) {
-            _results.resize(task_idx + 1);
-          }
           int count;
           DYNAMPI_MPI_CHECK(MPI_Get_count, (&status, result_type::value, &count));
           // Resize buffer to actual received count (may be less than max_result_size)
           result_type::resize(buffer, count);
-          // Statistics already updated by recv_any, but need to adjust for actual count
-          // The statistics were updated with max_result_size, so we need to correct them
-          if constexpr (statistics_mode != StatisticsMode::None) {
-            int size;
-            MPI_Type_size(result_type::value, &size);
-            _communicator.adjust_recv_bytes_received((_config.max_result_size - count) * size);
-          }
-          // Move buffer to results
-          result_type::resize(_results[task_idx], count);
-          _results[task_idx] = std::move(buffer);
-          _results_received++;
+          process_result_message(status, std::move(buffer), count);
         } else {
           assert(status.MPI_TAG == Tag::REQUEST && "Unexpected tag received");
-          // REQUEST messages are empty, statistics were updated incorrectly (as if we received
-          // data) Need to correct: remove the bytes_received that were added
-          if constexpr (statistics_mode != StatisticsMode::None) {
-            int size;
-            MPI_Type_size(result_type::value, &size);
-            _communicator.adjust_recv_bytes_received(_config.max_result_size * size);
-          }
         }
       } else {
-        // For fixed-size types, we can receive directly
         ResultT buffer;
         status = _communicator.recv_any(buffer);
 
         if (status.MPI_TAG == Tag::RESULT) {
-          int64_t task_idx =
-              _worker_current_task_indices[status.MPI_SOURCE -
-                                           (status.MPI_SOURCE > _config.manager_rank)];
-          _worker_current_task_indices[status.MPI_SOURCE -
-                                       (status.MPI_SOURCE > _config.manager_rank)] = -1;
-          assert(task_idx >= 0 && "Task index should be valid");
-          if (static_cast<uint64_t>(task_idx) >= _results.size()) {
-            _results.resize(task_idx + 1);
-          }
-          // Statistics already updated by recv_any
-          _results[task_idx] = std::move(buffer);
-          _results_received++;
+          int count;
+          DYNAMPI_MPI_CHECK(MPI_Get_count, (&status, result_type::value, &count));
+          process_result_message(status, std::move(buffer), count);
         } else {
           assert(status.MPI_TAG == Tag::REQUEST && "Unexpected tag received");
-          // REQUEST messages are empty, but recv_any updated statistics as if we received data
-          // Need to correct: remove the bytes_received that were added
-          if constexpr (statistics_mode != StatisticsMode::None) {
-            int size;
-            MPI_Type_size(result_type::value, &size);
-            _communicator.adjust_recv_bytes_received(result_type::count(buffer) * size);
-          }
         }
       }
     } else {
       // Probe mode: use probe to check message size before receiving
       status = _communicator.probe();
       if (status.MPI_TAG == Tag::RESULT) {
-        int64_t task_idx = _worker_current_task_indices[status.MPI_SOURCE -
-                                                        (status.MPI_SOURCE > _config.manager_rank)];
-        _worker_current_task_indices[status.MPI_SOURCE -
-                                     (status.MPI_SOURCE > _config.manager_rank)] = -1;
-        assert(task_idx >= 0 && "Task index should be valid");
-        if (static_cast<uint64_t>(task_idx) >= _results.size()) {
-          _results.resize(task_idx + 1);
-        }
         int count;
         DYNAMPI_MPI_CHECK(MPI_Get_count, (&status, result_type::value, &count));
-        result_type::resize(_results[task_idx], count);
-        _communicator.recv(_results[task_idx], status.MPI_SOURCE, Tag::RESULT);
-        _results_received++;
+        ResultT buffer;
+        if constexpr (result_type::resize_required) {
+          result_type::resize(buffer, count);
+        }
+        _communicator.recv(buffer, status.MPI_SOURCE, Tag::RESULT);
+        process_result_message(status, std::move(buffer), count);
       } else {
         assert(status.MPI_TAG == Tag::REQUEST && "Unexpected tag received in worker");
         _communicator.recv_empty_message(status.MPI_SOURCE, Tag::REQUEST);

--- a/include/dynampi/impl/naive_distributor.hpp
+++ b/include/dynampi/impl/naive_distributor.hpp
@@ -30,6 +30,10 @@ class NaiveMPIWorkDistributor {
     MPI_Comm comm = MPI_COMM_WORLD;
     int manager_rank = 0;
     bool auto_run_workers = true;
+    bool use_immediate_recv = false;
+    int max_result_size = 1024;  // Maximum expected size for RESULT messages when using immediate
+                                 // recv. Must be large enough to hold the largest expected RESULT
+                                 // message. If a message exceeds this size, behavior is undefined.
   };
 
  private:
@@ -102,8 +106,7 @@ class NaiveMPIWorkDistributor {
     using task_type = MPI_Type<TaskT>;
     _communicator.send(nullptr, _config.manager_rank, Tag::REQUEST);
     while (true) {
-      MPI_Status status;
-      DYNAMPI_MPI_CHECK(MPI_Probe, (MPI_ANY_SOURCE, MPI_ANY_TAG, _communicator.get(), &status));
+      MPI_Status status = _communicator.probe();
       if (status.MPI_TAG == Tag::DONE) {
         _communicator.recv_empty_message(_config.manager_rank, Tag::DONE);
         break;
@@ -248,24 +251,101 @@ class NaiveMPIWorkDistributor {
            "There should be at least one worker to receive results from");
     using result_type = MPI_Type<ResultT>;
     MPI_Status status;
-    DYNAMPI_MPI_CHECK(MPI_Probe, (MPI_ANY_SOURCE, MPI_ANY_TAG, _communicator.get(), &status));
-    if (status.MPI_TAG == Tag::RESULT) {
-      int64_t task_idx = _worker_current_task_indices[status.MPI_SOURCE -
-                                                      (status.MPI_SOURCE > _config.manager_rank)];
-      _worker_current_task_indices[status.MPI_SOURCE - (status.MPI_SOURCE > _config.manager_rank)] =
-          -1;
-      assert(task_idx >= 0 && "Task index should be valid");
-      if (static_cast<uint64_t>(task_idx) >= _results.size()) {
-        _results.resize(task_idx + 1);
+
+    if (_config.use_immediate_recv) {
+      // Immediate receive mode: use recv_any with predetermined buffer size
+      // For REQUEST messages (empty), we can receive with a null buffer
+      // For RESULT messages, we use the predetermined buffer size
+      if constexpr (result_type::resize_required) {
+        ResultT buffer;
+        result_type::resize(buffer, _config.max_result_size);
+        status = _communicator.recv_any(buffer);
+
+        if (status.MPI_TAG == Tag::RESULT) {
+          int64_t task_idx =
+              _worker_current_task_indices[status.MPI_SOURCE -
+                                           (status.MPI_SOURCE > _config.manager_rank)];
+          _worker_current_task_indices[status.MPI_SOURCE -
+                                       (status.MPI_SOURCE > _config.manager_rank)] = -1;
+          assert(task_idx >= 0 && "Task index should be valid");
+          if (static_cast<uint64_t>(task_idx) >= _results.size()) {
+            _results.resize(task_idx + 1);
+          }
+          int count;
+          DYNAMPI_MPI_CHECK(MPI_Get_count, (&status, result_type::value, &count));
+          // Resize buffer to actual received count (may be less than max_result_size)
+          result_type::resize(buffer, count);
+          // Statistics already updated by recv_any, but need to adjust for actual count
+          // The statistics were updated with max_result_size, so we need to correct them
+          if constexpr (statistics_mode != StatisticsMode::None) {
+            int size;
+            MPI_Type_size(result_type::value, &size);
+            _communicator.adjust_recv_bytes_received((_config.max_result_size - count) * size);
+          }
+          // Move buffer to results
+          result_type::resize(_results[task_idx], count);
+          _results[task_idx] = std::move(buffer);
+          _results_received++;
+        } else {
+          assert(status.MPI_TAG == Tag::REQUEST && "Unexpected tag received");
+          // REQUEST messages are empty, statistics were updated incorrectly (as if we received
+          // data) Need to correct: remove the bytes_received that were added
+          if constexpr (statistics_mode != StatisticsMode::None) {
+            int size;
+            MPI_Type_size(result_type::value, &size);
+            _communicator.adjust_recv_bytes_received(_config.max_result_size * size);
+          }
+        }
+      } else {
+        // For fixed-size types, we can receive directly
+        ResultT buffer;
+        status = _communicator.recv_any(buffer);
+
+        if (status.MPI_TAG == Tag::RESULT) {
+          int64_t task_idx =
+              _worker_current_task_indices[status.MPI_SOURCE -
+                                           (status.MPI_SOURCE > _config.manager_rank)];
+          _worker_current_task_indices[status.MPI_SOURCE -
+                                       (status.MPI_SOURCE > _config.manager_rank)] = -1;
+          assert(task_idx >= 0 && "Task index should be valid");
+          if (static_cast<uint64_t>(task_idx) >= _results.size()) {
+            _results.resize(task_idx + 1);
+          }
+          // Statistics already updated by recv_any
+          _results[task_idx] = std::move(buffer);
+          _results_received++;
+        } else {
+          assert(status.MPI_TAG == Tag::REQUEST && "Unexpected tag received");
+          // REQUEST messages are empty, but recv_any updated statistics as if we received data
+          // Need to correct: remove the bytes_received that were added
+          if constexpr (statistics_mode != StatisticsMode::None) {
+            int size;
+            MPI_Type_size(result_type::value, &size);
+            _communicator.adjust_recv_bytes_received(result_type::count(buffer) * size);
+          }
+        }
       }
-      int count;
-      DYNAMPI_MPI_CHECK(MPI_Get_count, (&status, result_type::value, &count));
-      result_type::resize(_results[task_idx], count);
-      _communicator.recv(_results[task_idx], status.MPI_SOURCE, Tag::RESULT);
-      _results_received++;
     } else {
-      assert(status.MPI_TAG == Tag::REQUEST && "Unexpected tag received in worker");
-      _communicator.recv_empty_message(status.MPI_SOURCE, Tag::REQUEST);
+      // Probe mode: use probe to check message size before receiving
+      status = _communicator.probe();
+      if (status.MPI_TAG == Tag::RESULT) {
+        int64_t task_idx = _worker_current_task_indices[status.MPI_SOURCE -
+                                                        (status.MPI_SOURCE > _config.manager_rank)];
+        _worker_current_task_indices[status.MPI_SOURCE -
+                                     (status.MPI_SOURCE > _config.manager_rank)] = -1;
+        assert(task_idx >= 0 && "Task index should be valid");
+        if (static_cast<uint64_t>(task_idx) >= _results.size()) {
+          _results.resize(task_idx + 1);
+        }
+        int count;
+        DYNAMPI_MPI_CHECK(MPI_Get_count, (&status, result_type::value, &count));
+        result_type::resize(_results[task_idx], count);
+        _communicator.recv(_results[task_idx], status.MPI_SOURCE, Tag::RESULT);
+        _results_received++;
+      } else {
+        assert(status.MPI_TAG == Tag::REQUEST && "Unexpected tag received in worker");
+        _communicator.recv_empty_message(status.MPI_SOURCE, Tag::REQUEST);
+      }
     }
     _free_worker_indices.push(status.MPI_SOURCE);
   }

--- a/include/dynampi/mpi/mpi_communicator.hpp
+++ b/include/dynampi/mpi/mpi_communicator.hpp
@@ -156,13 +156,16 @@ class MPICommunicator {
   template <typename T>
   inline void recv(T& data, int source, int tag = 0) {
     using mpi_type = MPI_Type<T>;
+    MPI_Status status;
     DYNAMPI_MPI_CHECK(MPI_Recv, (mpi_type::ptr(data), mpi_type::count(data), mpi_type::value,
-                                 source, tag, _comm, MPI_STATUS_IGNORE));
+                                 source, tag, _comm, &status));
     if constexpr (statistics_mode != StatisticsMode::None) {
       _statistics.recv_count++;
+      int actual_count;
+      DYNAMPI_MPI_CHECK(MPI_Get_count, (&status, mpi_type::value, &actual_count));
       int size;
       MPI_Type_size(mpi_type::value, &size);
-      _statistics.bytes_received += mpi_type::count(data) * size;
+      _statistics.bytes_received += actual_count * size;
     }
   }
 
@@ -182,9 +185,11 @@ class MPICommunicator {
                                  source, tag, _comm, &status));
     if constexpr (statistics_mode != StatisticsMode::None) {
       _statistics.recv_count++;
+      int actual_count;
+      DYNAMPI_MPI_CHECK(MPI_Get_count, (&status, mpi_type::value, &actual_count));
       int size;
       MPI_Type_size(mpi_type::value, &size);
-      _statistics.bytes_received += mpi_type::count(data) * size;
+      _statistics.bytes_received += actual_count * size;
     }
     return status;
   }
@@ -225,13 +230,6 @@ class MPICommunicator {
       _statistics.recv_count++;
     }
     return status;
-  }
-
-  // Helper to adjust receive statistics (subtract bytes that were incorrectly counted)
-  void adjust_recv_bytes_received(size_t bytes_to_subtract) {
-    if constexpr (statistics_mode != StatisticsMode::None) {
-      _statistics.bytes_received -= bytes_to_subtract;
-    }
   }
 
   [[nodiscard]] MPI_Comm get() const { return _comm; }

--- a/include/dynampi/mpi/mpi_communicator.hpp
+++ b/include/dynampi/mpi/mpi_communicator.hpp
@@ -220,6 +220,28 @@ class MPICommunicator {
     }
   }
 
+  /// Sends 0 elements of type T (same type as recv buffer) so that recv_any(T&) can receive any
+  /// worker message (REQUEST or RESULT) into a single buffer type.
+  template <typename T>
+  inline void send_empty(int dest, int tag = 0) {
+    using mpi_type = MPI_Type<T>;
+    DYNAMPI_MPI_CHECK(MPI_Send, (nullptr, 0, mpi_type::value, dest, tag, _comm));
+    if constexpr (statistics_mode != StatisticsMode::None) {
+      _statistics.send_count++;
+    }
+  }
+
+  /// Receives 0 elements of type T. Use when the sender used send_empty<T>.
+  template <typename T>
+  inline void recv_empty(int source, int tag = 0) {
+    using mpi_type = MPI_Type<T>;
+    DYNAMPI_MPI_CHECK(MPI_Recv,
+                      (nullptr, 0, mpi_type::value, source, tag, _comm, MPI_STATUS_IGNORE));
+    if constexpr (statistics_mode != StatisticsMode::None) {
+      _statistics.recv_count++;
+    }
+  }
+
   [[nodiscard]] MPI_Comm get() const { return _comm; }
 };
 

--- a/include/dynampi/mpi/mpi_communicator.hpp
+++ b/include/dynampi/mpi/mpi_communicator.hpp
@@ -220,18 +220,6 @@ class MPICommunicator {
     }
   }
 
-  // Receive empty message with MPI_ANY_SOURCE/MPI_ANY_TAG and return status
-  inline MPI_Status recv_empty_message_any(int source = MPI_ANY_SOURCE, int tag = MPI_ANY_TAG) {
-    using mpi_type = MPI_Type<std::nullptr_t>;
-    MPI_Status status;
-    DYNAMPI_MPI_CHECK(MPI_Recv, (nullptr, mpi_type::count(nullptr), mpi_type::value, source, tag,
-                                 _comm, &status));
-    if constexpr (statistics_mode != StatisticsMode::None) {
-      _statistics.recv_count++;
-    }
-    return status;
-  }
-
   [[nodiscard]] MPI_Comm get() const { return _comm; }
 };
 

--- a/include/dynampi/mpi/mpi_communicator.hpp
+++ b/include/dynampi/mpi/mpi_communicator.hpp
@@ -166,6 +166,29 @@ class MPICommunicator {
     }
   }
 
+  // Probe for a message, returns status
+  inline MPI_Status probe(int source = MPI_ANY_SOURCE, int tag = MPI_ANY_TAG) {
+    MPI_Status status;
+    DYNAMPI_MPI_CHECK(MPI_Probe, (source, tag, _comm, &status));
+    return status;
+  }
+
+  // Receive with MPI_ANY_SOURCE/MPI_ANY_TAG and return status
+  template <typename T>
+  inline MPI_Status recv_any(T& data, int source = MPI_ANY_SOURCE, int tag = MPI_ANY_TAG) {
+    using mpi_type = MPI_Type<T>;
+    MPI_Status status;
+    DYNAMPI_MPI_CHECK(MPI_Recv, (mpi_type::ptr(data), mpi_type::count(data), mpi_type::value,
+                                 source, tag, _comm, &status));
+    if constexpr (statistics_mode != StatisticsMode::None) {
+      _statistics.recv_count++;
+      int size;
+      MPI_Type_size(mpi_type::value, &size);
+      _statistics.bytes_received += mpi_type::count(data) * size;
+    }
+    return status;
+  }
+
   template <typename T>
   inline void broadcast(T& data, int root = 0) {
     using mpi_type = MPI_Type<T>;
@@ -189,6 +212,25 @@ class MPICommunicator {
                                  _comm, MPI_STATUS_IGNORE));
     if constexpr (statistics_mode != StatisticsMode::None) {
       _statistics.recv_count++;
+    }
+  }
+
+  // Receive empty message with MPI_ANY_SOURCE/MPI_ANY_TAG and return status
+  inline MPI_Status recv_empty_message_any(int source = MPI_ANY_SOURCE, int tag = MPI_ANY_TAG) {
+    using mpi_type = MPI_Type<std::nullptr_t>;
+    MPI_Status status;
+    DYNAMPI_MPI_CHECK(MPI_Recv, (nullptr, mpi_type::count(nullptr), mpi_type::value, source, tag,
+                                 _comm, &status));
+    if constexpr (statistics_mode != StatisticsMode::None) {
+      _statistics.recv_count++;
+    }
+    return status;
+  }
+
+  // Helper to adjust receive statistics (subtract bytes that were incorrectly counted)
+  void adjust_recv_bytes_received(size_t bytes_to_subtract) {
+    if constexpr (statistics_mode != StatisticsMode::None) {
+      _statistics.bytes_received -= bytes_to_subtract;
     }
   }
 

--- a/test/mpi/test_distributers.cpp
+++ b/test/mpi/test_distributers.cpp
@@ -30,7 +30,7 @@ template <typename T>
 class DynamicDistribution : public ::testing::Test {
  protected:
   template <typename TaskT, typename ResultT, typename... Options>
-  auto make_distributor(auto worker_task) {
+  auto make_distributor(auto worker_task, bool auto_run = false) {
     using DistT = typename T::template type<TaskT, ResultT, Options...>;
 
     // Use decltype to get the correct Options type regardless of its internal name
@@ -38,7 +38,7 @@ class DynamicDistribution : public ::testing::Test {
 
     ConfigT opts{};
     opts.comm = MPI_COMM_WORLD;
-    opts.auto_run_workers = false;
+    opts.auto_run_workers = auto_run;
 
     if constexpr (T::use_immediate_recv) {
       opts.use_immediate_recv = true;
@@ -120,9 +120,41 @@ TYPED_TEST(DynamicDistribution, Statistics) {
     auto results = dist.finish_remaining_tasks();
 
     size_t expected_size = (MPIEnvironment::world_comm_size() == 1) ? 0 : 5;
+    EXPECT_EQ(results, (std::vector<int>{1, 4, 9, 16, 25}));
     EXPECT_EQ(dist.get_statistics().comm_statistics.send_count, expected_size);
+    EXPECT_EQ(dist.get_statistics().comm_statistics.bytes_sent, expected_size * sizeof(int));
+    EXPECT_EQ(dist.get_statistics().comm_statistics.recv_count,
+              expected_size + MPIEnvironment::world_comm_size() - 1);
+    EXPECT_EQ(dist.get_statistics().comm_statistics.bytes_received, expected_size * sizeof(int));
+
     dist.finalize();
+    EXPECT_EQ(dist.get_statistics().comm_statistics.send_count,
+              expected_size + MPIEnvironment::world_comm_size() - 1);
+    EXPECT_EQ(dist.get_statistics().comm_statistics.bytes_sent, expected_size * sizeof(int));
+
+    double expected_num_bytes = 0;
+    if (MPIEnvironment::world_comm_size() > 1) {
+      expected_num_bytes = static_cast<double>(expected_size * sizeof(int)) /
+                           (expected_size + MPIEnvironment::world_comm_size() - 1);
+    }
+    EXPECT_DOUBLE_EQ(dist.get_statistics().comm_statistics.average_receive_size(),
+                     expected_num_bytes);
+    EXPECT_DOUBLE_EQ(dist.get_statistics().comm_statistics.average_send_size(), expected_num_bytes);
   } else {
     dist.run_worker();
   }
+}
+
+TYPED_TEST(DynamicDistribution, AutoRunWorkers) {
+  auto worker_task = [](int task) -> int { return task * task; };
+  // Test with auto_run_workers = true - workers should start automatically
+  auto dist = this->template make_distributor<int, int>(worker_task, true);
+
+  if (dist.is_root_manager()) {
+    // Workers should already be running, so we can just insert tasks
+    dist.insert_tasks({1, 2, 3, 4, 5});
+    auto results = dist.finish_remaining_tasks();
+    EXPECT_EQ(results, (std::vector<int>{1, 4, 9, 16, 25}));
+  }
+  // Workers run automatically in constructor, no need to call run_worker()
 }

--- a/test/mpi/test_distributers.cpp
+++ b/test/mpi/test_distributers.cpp
@@ -15,300 +15,114 @@
 #include "dynampi/mpi/mpi_communicator.hpp"
 #include "mpi_test_environment.hpp"
 
-template <template <typename, typename, typename...> class TT>
-struct DistributerTypeWrapper {
+// --- Configuration Wrapper ---
+template <template <typename, typename, typename...> class DistributorT, bool ImmediateRecv = false>
+struct TestConfig {
   template <typename TaskT, typename ResultT, typename... Options>
-  using type = TT<TaskT, ResultT, Options...>;
+  using type = DistributorT<TaskT, ResultT, Options...>;
+
+  static constexpr bool use_immediate_recv = ImmediateRecv;
+  static constexpr size_t max_result_size = 1024;
 };
 
-template <typename Wrapper, typename... T>
-using DistributerOf = typename Wrapper::template type<T...>;
-
-// Test fixture
+// --- Unified Test Fixture ---
 template <typename T>
-class DynamicDistribution : public ::testing::Test {};
+class DynamicDistribution : public ::testing::Test {
+ protected:
+  template <typename TaskT, typename ResultT, typename... Options>
+  auto make_distributor(auto worker_task) {
+    using DistT = typename T::template type<TaskT, ResultT, Options...>;
+
+    // Use decltype to get the correct Options type regardless of its internal name
+    using ConfigT = typename DistT::Config;
+
+    ConfigT opts{};
+    opts.comm = MPI_COMM_WORLD;
+    opts.auto_run_workers = false;
+
+    if constexpr (T::use_immediate_recv) {
+      opts.use_immediate_recv = true;
+      opts.max_result_size = T::max_result_size;
+    }
+
+    return DistT(worker_task, opts);
+  }
+};
 
 using DistributerTypes =
-    ::testing::Types<DistributerTypeWrapper<dynampi::HierarchicalMPIWorkDistributor>,
-                     DistributerTypeWrapper<dynampi::NaiveMPIWorkDistributor>>;
+    ::testing::Types<TestConfig<dynampi::NaiveMPIWorkDistributor, false>,
+                     TestConfig<dynampi::NaiveMPIWorkDistributor, true>,
+                     TestConfig<dynampi::HierarchicalMPIWorkDistributor, false>>;
 
 TYPED_TEST_SUITE(DynamicDistribution, DistributerTypes);
 
-// Test fixture for immediate receive mode (only NaiveMPIWorkDistributor supports this)
-using ImmediateRecvDistributerTypes =
-    ::testing::Types<DistributerTypeWrapper<dynampi::NaiveMPIWorkDistributor>>;
+// --- Tests are now much leaner ---
 
-template <typename T>
-class DynamicDistributionImmediateRecv : public ::testing::Test {};
+TYPED_TEST(DynamicDistribution, BasicFlow) {
+  auto worker_task = [](uint32_t task) -> double { return sqrt(static_cast<double>(task)); };
+  auto dist = this->template make_distributor<uint32_t, double>(worker_task);
 
-TYPED_TEST_SUITE(DynamicDistributionImmediateRecv, ImmediateRecvDistributerTypes);
-
-TYPED_TEST(DynamicDistribution, Naive) {
-  using TaskT = uint32_t;
-  using Distributer = DistributerOf<TypeParam, TaskT, double>;
-
-  auto worker_task = [](TaskT task) -> double { return sqrt(static_cast<double>(task)); };
-
-  std::vector<TaskT> tasks(10);
-  for (size_t i = 0; i < tasks.size(); ++i) tasks[i] = static_cast<TaskT>(i);
-
-  Distributer distributor(worker_task, {.comm = MPI_COMM_WORLD, .auto_run_workers = false});
-
-  if (distributor.is_root_manager()) {
-    for (int i = 0; i < 10; ++i) distributor.insert_task(i);
-  }
-
-  if (distributor.is_root_manager()) {
-    auto results = distributor.finish_remaining_tasks();
+  if (dist.is_root_manager()) {
+    for (int i = 0; i < 10; ++i) dist.insert_task(i);
+    auto results = dist.finish_remaining_tasks();
     EXPECT_EQ(results.size(), 10);
     for (size_t i = 0; i < results.size(); ++i) {
       EXPECT_DOUBLE_EQ(results[i] * results[i], static_cast<double>(i));
     }
   } else {
-    distributor.run_worker();
+    dist.run_worker();
   }
 }
 
-TYPED_TEST(DynamicDistribution, Naive2) {
-  using DistributerWrapper = TypeParam;
-
-  auto worker_task = [](size_t task) -> char { return "Hi"[task]; };
-
-  auto result = dynampi::mpi_manager_worker_distribution<char, DistributerWrapper::template type>(
-      2, worker_task);
-
-  if (MPIEnvironment::world_comm_rank() == 0) {
-    EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(result->size(), 2);
-  } else {
-    EXPECT_FALSE(result.has_value());
-  }
-}
-
-TYPED_TEST(DynamicDistribution, Example1) {
-  using DistributerWrapper = TypeParam;
-
-  for (int manager_rank : {0, MPIEnvironment::world_comm_size() - 1}) {
-    auto worker_task = [](size_t task) -> size_t { return task * task; };
-    auto result =
-        dynampi::mpi_manager_worker_distribution<size_t, DistributerWrapper::template type>(
-            4, worker_task, MPI_COMM_WORLD, manager_rank);
-    if (result.has_value()) {
-      assert(result == std::vector<size_t>({0, 1, 4, 9}));
-      EXPECT_EQ(result, std::vector<size_t>({0, 1, 4, 9}));
-    }
-  }
-}
-
-TYPED_TEST(DynamicDistribution, Example2) {
-  using Task = int;
+TYPED_TEST(DynamicDistribution, MultiStageTasks) {
   using Result = std::vector<int>;
-  using Distributer = DistributerOf<TypeParam, Task, Result>;
-  auto worker_task = [](Task task) -> Result {
-    return Result{task, task * task, task * task * task};
-  };
-  {
-    Distributer work_distributer(worker_task);
-    if (work_distributer.is_root_manager()) {
-      work_distributer.insert_tasks({1, 2, 3, 4, 5});
-      auto results = work_distributer.finish_remaining_tasks();
-      EXPECT_EQ(results, (std::vector<std::vector<int>>{
-                             {1, 1, 1}, {2, 4, 8}, {3, 9, 27}, {4, 16, 64}, {5, 25, 125}}));
-      work_distributer.insert_tasks({6, 7, 8});
-      results = work_distributer.finish_remaining_tasks();
-      EXPECT_EQ(results, (std::vector<std::vector<int>>{{1, 1, 1},
-                                                        {2, 4, 8},
-                                                        {3, 9, 27},
-                                                        {4, 16, 64},
-                                                        {5, 25, 125},
-                                                        {6, 36, 216},
-                                                        {7, 49, 343},
-                                                        {8, 64, 512}}));
-    }
+  auto worker_task = [](int task) -> Result { return {task, task * task, task * task * task}; };
+  auto dist = this->template make_distributor<int, Result>(worker_task);
+
+  if (dist.is_root_manager()) {
+    dist.insert_tasks({1, 2, 3, 4, 5});
+    EXPECT_EQ(dist.finish_remaining_tasks().size(), 5);
+
+    dist.insert_tasks({6, 7, 8});
+    auto results = dist.finish_remaining_tasks();
+    EXPECT_EQ(results.size(), 8);
+    EXPECT_EQ(results.back(), (Result{8, 64, 512}));
+  } else {
+    dist.run_worker();
   }
 }
 
 TYPED_TEST(DynamicDistribution, PriorityQueue) {
-  using Task = int;
-  using Result = int;
-  using Distributer = DistributerOf<TypeParam, Task, Result, dynampi::enable_prioritization>;
-  auto worker_task = [](Task task) -> Result { return task * task; };
-  {
-    Distributer work_distributer(worker_task);
-    if (work_distributer.is_root_manager()) {
-      work_distributer.insert_task(1, 1.0);
-      work_distributer.insert_task(7, 7.0);
-      work_distributer.insert_task(3, 3.0);
-      work_distributer.insert_task(6, 6.0);
-      work_distributer.insert_task(2, 2.0);
-      work_distributer.insert_task(4, 5.0);
-      work_distributer.insert_task(5, 4.0);
-      auto result = work_distributer.finish_remaining_tasks();
-      EXPECT_EQ(result, (std::vector<int>{49, 36, 16, 25, 9, 4, 1}));
-    }
+  auto worker_task = [](int task) -> int { return task * task; };
+  // Pass the priority option as a template argument to the factory
+  auto dist =
+      this->template make_distributor<int, int, dynampi::enable_prioritization>(worker_task);
+
+  if (dist.is_root_manager()) {
+    std::vector<std::pair<int, double>> tasks = {{1, 1.0}, {7, 7.0}, {3, 3.0}, {6, 6.0},
+                                                 {2, 2.0}, {4, 5.0}, {5, 4.0}};
+    for (auto& t : tasks) dist.insert_task(t.first, t.second);
+
+    auto result = dist.finish_remaining_tasks();
+    EXPECT_EQ(result, (std::vector<int>{49, 36, 16, 25, 9, 4, 1}));
+  } else {
+    dist.run_worker();
   }
 }
 
 TYPED_TEST(DynamicDistribution, Statistics) {
-  using Task = int;
-  using Result = int;
-  using Distributer = DistributerOf<TypeParam, Task, Result,
-                                    dynampi::track_statistics<dynampi::StatisticsMode::Detailed>>;
-  auto worker_task = [](Task task) -> Result { return task * task; };
-  {
-    Distributer work_distributer(worker_task);
-    if (work_distributer.is_root_manager()) {
-      work_distributer.insert_tasks({1, 2, 3, 4, 5});
-      auto results = work_distributer.finish_remaining_tasks();
-      size_t expected_size = 5;
-      if (MPIEnvironment::world_comm_size() == 1) {
-        expected_size = 0;
-      }
-      EXPECT_EQ(results, (std::vector<int>{1, 4, 9, 16, 25}));
-      EXPECT_EQ(work_distributer.get_statistics().comm_statistics.send_count, expected_size);
-      EXPECT_EQ(work_distributer.get_statistics().comm_statistics.bytes_sent,
-                expected_size * sizeof(int));
-      EXPECT_EQ(work_distributer.get_statistics().comm_statistics.recv_count,
-                expected_size + MPIEnvironment::world_comm_size() - 1);
-      EXPECT_EQ(work_distributer.get_statistics().comm_statistics.bytes_received,
-                expected_size * sizeof(int));
-      work_distributer.finalize();
-      EXPECT_EQ(work_distributer.get_statistics().comm_statistics.send_count,
-                expected_size + MPIEnvironment::world_comm_size() - 1);
-      EXPECT_EQ(work_distributer.get_statistics().comm_statistics.bytes_sent,
-                expected_size * sizeof(int));
-      double expected_num_bytes = 0;
-      if (MPIEnvironment::world_comm_size() > 1) {
-        expected_num_bytes = static_cast<double>(expected_size * sizeof(int)) /
-                             (expected_size + MPIEnvironment::world_comm_size() - 1);
-      }
-      EXPECT_DOUBLE_EQ(work_distributer.get_statistics().comm_statistics.average_receive_size(),
-                       expected_num_bytes);
-      EXPECT_DOUBLE_EQ(work_distributer.get_statistics().comm_statistics.average_send_size(),
-                       expected_num_bytes);
-    }
-  }
-}
+  auto worker_task = [](int task) -> int { return task * task; };
+  using StatsOpt = dynampi::track_statistics<dynampi::StatisticsMode::Detailed>;
+  auto dist = this->template make_distributor<int, int, StatsOpt>(worker_task);
 
-// Tests with immediate receive enabled
-TYPED_TEST(DynamicDistributionImmediateRecv, Naive) {
-  using TaskT = uint32_t;
-  using Distributer = DistributerOf<TypeParam, TaskT, double>;
+  if (dist.is_root_manager()) {
+    dist.insert_tasks({1, 2, 3, 4, 5});
+    auto results = dist.finish_remaining_tasks();
 
-  auto worker_task = [](TaskT task) -> double { return sqrt(static_cast<double>(task)); };
-
-  std::vector<TaskT> tasks(10);
-  for (size_t i = 0; i < tasks.size(); ++i) tasks[i] = static_cast<TaskT>(i);
-
-  Distributer distributor(worker_task, {.comm = MPI_COMM_WORLD,
-                                        .auto_run_workers = false,
-                                        .use_immediate_recv = true,
-                                        .max_result_size = 1024});
-
-  if (distributor.is_root_manager()) {
-    for (int i = 0; i < 10; ++i) distributor.insert_task(i);
-  }
-
-  if (distributor.is_root_manager()) {
-    auto results = distributor.finish_remaining_tasks();
-    EXPECT_EQ(results.size(), 10);
-    for (size_t i = 0; i < results.size(); ++i) {
-      EXPECT_DOUBLE_EQ(results[i] * results[i], static_cast<double>(i));
-    }
+    size_t expected_size = (MPIEnvironment::world_comm_size() == 1) ? 0 : 5;
+    EXPECT_EQ(dist.get_statistics().comm_statistics.send_count, expected_size);
+    dist.finalize();
   } else {
-    distributor.run_worker();
-  }
-}
-
-TYPED_TEST(DynamicDistributionImmediateRecv, Example2) {
-  using Task = int;
-  using Result = std::vector<int>;
-  using Distributer = DistributerOf<TypeParam, Task, Result>;
-  auto worker_task = [](Task task) -> Result {
-    return Result{task, task * task, task * task * task};
-  };
-  {
-    Distributer work_distributer(worker_task,
-                                 {.use_immediate_recv = true, .max_result_size = 1024});
-    if (work_distributer.is_root_manager()) {
-      work_distributer.insert_tasks({1, 2, 3, 4, 5});
-      auto results = work_distributer.finish_remaining_tasks();
-      EXPECT_EQ(results, (std::vector<std::vector<int>>{
-                             {1, 1, 1}, {2, 4, 8}, {3, 9, 27}, {4, 16, 64}, {5, 25, 125}}));
-      work_distributer.insert_tasks({6, 7, 8});
-      results = work_distributer.finish_remaining_tasks();
-      EXPECT_EQ(results, (std::vector<std::vector<int>>{{1, 1, 1},
-                                                        {2, 4, 8},
-                                                        {3, 9, 27},
-                                                        {4, 16, 64},
-                                                        {5, 25, 125},
-                                                        {6, 36, 216},
-                                                        {7, 49, 343},
-                                                        {8, 64, 512}}));
-    }
-  }
-}
-
-TYPED_TEST(DynamicDistributionImmediateRecv, PriorityQueue) {
-  using Task = int;
-  using Result = int;
-  using Distributer = DistributerOf<TypeParam, Task, Result, dynampi::enable_prioritization>;
-  auto worker_task = [](Task task) -> Result { return task * task; };
-  {
-    Distributer work_distributer(worker_task,
-                                 {.use_immediate_recv = true, .max_result_size = 1024});
-    if (work_distributer.is_root_manager()) {
-      work_distributer.insert_task(1, 1.0);
-      work_distributer.insert_task(7, 7.0);
-      work_distributer.insert_task(3, 3.0);
-      work_distributer.insert_task(6, 6.0);
-      work_distributer.insert_task(2, 2.0);
-      work_distributer.insert_task(4, 5.0);
-      work_distributer.insert_task(5, 4.0);
-      auto result = work_distributer.finish_remaining_tasks();
-      EXPECT_EQ(result, (std::vector<int>{49, 36, 16, 25, 9, 4, 1}));
-    }
-  }
-}
-
-TYPED_TEST(DynamicDistributionImmediateRecv, Statistics) {
-  using Task = int;
-  using Result = int;
-  using Distributer = DistributerOf<TypeParam, Task, Result,
-                                    dynampi::track_statistics<dynampi::StatisticsMode::Detailed>>;
-  auto worker_task = [](Task task) -> Result { return task * task; };
-  {
-    Distributer work_distributer(worker_task,
-                                 {.use_immediate_recv = true, .max_result_size = 1024});
-    if (work_distributer.is_root_manager()) {
-      work_distributer.insert_tasks({1, 2, 3, 4, 5});
-      auto results = work_distributer.finish_remaining_tasks();
-      size_t expected_size = 5;
-      if (MPIEnvironment::world_comm_size() == 1) {
-        expected_size = 0;
-      }
-      EXPECT_EQ(results, (std::vector<int>{1, 4, 9, 16, 25}));
-      EXPECT_EQ(work_distributer.get_statistics().comm_statistics.send_count, expected_size);
-      EXPECT_EQ(work_distributer.get_statistics().comm_statistics.bytes_sent,
-                expected_size * sizeof(int));
-      EXPECT_EQ(work_distributer.get_statistics().comm_statistics.recv_count,
-                expected_size + MPIEnvironment::world_comm_size() - 1);
-      EXPECT_EQ(work_distributer.get_statistics().comm_statistics.bytes_received,
-                expected_size * sizeof(int));
-      work_distributer.finalize();
-      EXPECT_EQ(work_distributer.get_statistics().comm_statistics.send_count,
-                expected_size + MPIEnvironment::world_comm_size() - 1);
-      EXPECT_EQ(work_distributer.get_statistics().comm_statistics.bytes_sent,
-                expected_size * sizeof(int));
-      double expected_num_bytes = 0;
-      if (MPIEnvironment::world_comm_size() > 1) {
-        expected_num_bytes = static_cast<double>(expected_size * sizeof(int)) /
-                             (expected_size + MPIEnvironment::world_comm_size() - 1);
-      }
-      EXPECT_DOUBLE_EQ(work_distributer.get_statistics().comm_statistics.average_receive_size(),
-                       expected_num_bytes);
-      EXPECT_DOUBLE_EQ(work_distributer.get_statistics().comm_statistics.average_send_size(),
-                       expected_num_bytes);
-    }
+    dist.run_worker();
   }
 }

--- a/test/mpi/test_distributers.cpp
+++ b/test/mpi/test_distributers.cpp
@@ -34,6 +34,15 @@ using DistributerTypes =
 
 TYPED_TEST_SUITE(DynamicDistribution, DistributerTypes);
 
+// Test fixture for immediate receive mode (only NaiveMPIWorkDistributor supports this)
+using ImmediateRecvDistributerTypes =
+    ::testing::Types<DistributerTypeWrapper<dynampi::NaiveMPIWorkDistributor>>;
+
+template <typename T>
+class DynamicDistributionImmediateRecv : public ::testing::Test {};
+
+TYPED_TEST_SUITE(DynamicDistributionImmediateRecv, ImmediateRecvDistributerTypes);
+
 TYPED_TEST(DynamicDistribution, Naive) {
   using TaskT = uint32_t;
   using Distributer = DistributerOf<TypeParam, TaskT, double>;
@@ -148,6 +157,129 @@ TYPED_TEST(DynamicDistribution, Statistics) {
   auto worker_task = [](Task task) -> Result { return task * task; };
   {
     Distributer work_distributer(worker_task);
+    if (work_distributer.is_root_manager()) {
+      work_distributer.insert_tasks({1, 2, 3, 4, 5});
+      auto results = work_distributer.finish_remaining_tasks();
+      size_t expected_size = 5;
+      if (MPIEnvironment::world_comm_size() == 1) {
+        expected_size = 0;
+      }
+      EXPECT_EQ(results, (std::vector<int>{1, 4, 9, 16, 25}));
+      EXPECT_EQ(work_distributer.get_statistics().comm_statistics.send_count, expected_size);
+      EXPECT_EQ(work_distributer.get_statistics().comm_statistics.bytes_sent,
+                expected_size * sizeof(int));
+      EXPECT_EQ(work_distributer.get_statistics().comm_statistics.recv_count,
+                expected_size + MPIEnvironment::world_comm_size() - 1);
+      EXPECT_EQ(work_distributer.get_statistics().comm_statistics.bytes_received,
+                expected_size * sizeof(int));
+      work_distributer.finalize();
+      EXPECT_EQ(work_distributer.get_statistics().comm_statistics.send_count,
+                expected_size + MPIEnvironment::world_comm_size() - 1);
+      EXPECT_EQ(work_distributer.get_statistics().comm_statistics.bytes_sent,
+                expected_size * sizeof(int));
+      double expected_num_bytes = 0;
+      if (MPIEnvironment::world_comm_size() > 1) {
+        expected_num_bytes = static_cast<double>(expected_size * sizeof(int)) /
+                             (expected_size + MPIEnvironment::world_comm_size() - 1);
+      }
+      EXPECT_DOUBLE_EQ(work_distributer.get_statistics().comm_statistics.average_receive_size(),
+                       expected_num_bytes);
+      EXPECT_DOUBLE_EQ(work_distributer.get_statistics().comm_statistics.average_send_size(),
+                       expected_num_bytes);
+    }
+  }
+}
+
+// Tests with immediate receive enabled
+TYPED_TEST(DynamicDistributionImmediateRecv, Naive) {
+  using TaskT = uint32_t;
+  using Distributer = DistributerOf<TypeParam, TaskT, double>;
+
+  auto worker_task = [](TaskT task) -> double { return sqrt(static_cast<double>(task)); };
+
+  std::vector<TaskT> tasks(10);
+  for (size_t i = 0; i < tasks.size(); ++i) tasks[i] = static_cast<TaskT>(i);
+
+  Distributer distributor(worker_task, {.comm = MPI_COMM_WORLD,
+                                        .auto_run_workers = false,
+                                        .use_immediate_recv = true,
+                                        .max_result_size = 1024});
+
+  if (distributor.is_root_manager()) {
+    for (int i = 0; i < 10; ++i) distributor.insert_task(i);
+  }
+
+  if (distributor.is_root_manager()) {
+    auto results = distributor.finish_remaining_tasks();
+    EXPECT_EQ(results.size(), 10);
+    for (size_t i = 0; i < results.size(); ++i) {
+      EXPECT_DOUBLE_EQ(results[i] * results[i], static_cast<double>(i));
+    }
+  } else {
+    distributor.run_worker();
+  }
+}
+
+TYPED_TEST(DynamicDistributionImmediateRecv, Example2) {
+  using Task = int;
+  using Result = std::vector<int>;
+  using Distributer = DistributerOf<TypeParam, Task, Result>;
+  auto worker_task = [](Task task) -> Result {
+    return Result{task, task * task, task * task * task};
+  };
+  {
+    Distributer work_distributer(worker_task,
+                                 {.use_immediate_recv = true, .max_result_size = 1024});
+    if (work_distributer.is_root_manager()) {
+      work_distributer.insert_tasks({1, 2, 3, 4, 5});
+      auto results = work_distributer.finish_remaining_tasks();
+      EXPECT_EQ(results, (std::vector<std::vector<int>>{
+                             {1, 1, 1}, {2, 4, 8}, {3, 9, 27}, {4, 16, 64}, {5, 25, 125}}));
+      work_distributer.insert_tasks({6, 7, 8});
+      results = work_distributer.finish_remaining_tasks();
+      EXPECT_EQ(results, (std::vector<std::vector<int>>{{1, 1, 1},
+                                                        {2, 4, 8},
+                                                        {3, 9, 27},
+                                                        {4, 16, 64},
+                                                        {5, 25, 125},
+                                                        {6, 36, 216},
+                                                        {7, 49, 343},
+                                                        {8, 64, 512}}));
+    }
+  }
+}
+
+TYPED_TEST(DynamicDistributionImmediateRecv, PriorityQueue) {
+  using Task = int;
+  using Result = int;
+  using Distributer = DistributerOf<TypeParam, Task, Result, dynampi::enable_prioritization>;
+  auto worker_task = [](Task task) -> Result { return task * task; };
+  {
+    Distributer work_distributer(worker_task,
+                                 {.use_immediate_recv = true, .max_result_size = 1024});
+    if (work_distributer.is_root_manager()) {
+      work_distributer.insert_task(1, 1.0);
+      work_distributer.insert_task(7, 7.0);
+      work_distributer.insert_task(3, 3.0);
+      work_distributer.insert_task(6, 6.0);
+      work_distributer.insert_task(2, 2.0);
+      work_distributer.insert_task(4, 5.0);
+      work_distributer.insert_task(5, 4.0);
+      auto result = work_distributer.finish_remaining_tasks();
+      EXPECT_EQ(result, (std::vector<int>{49, 36, 16, 25, 9, 4, 1}));
+    }
+  }
+}
+
+TYPED_TEST(DynamicDistributionImmediateRecv, Statistics) {
+  using Task = int;
+  using Result = int;
+  using Distributer = DistributerOf<TypeParam, Task, Result,
+                                    dynampi::track_statistics<dynampi::StatisticsMode::Detailed>>;
+  auto worker_task = [](Task task) -> Result { return task * task; };
+  {
+    Distributer work_distributer(worker_task,
+                                 {.use_immediate_recv = true, .max_result_size = 1024});
     if (work_distributer.is_root_manager()) {
       work_distributer.insert_tasks({1, 2, 3, 4, 5});
       auto results = work_distributer.finish_remaining_tasks();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Immediate-receive mode with configurable immediate-receive toggle and result buffer cap; new communicator probe/recv-any helpers.
* **Bug Fixes**
  * Accurate receive accounting using actual received element counts; more reliable result sizing and worker reuse.
* **Tests**
  * Consolidated, parameterized distribution tests covering immediate and probe-based modes.
* **Chores**
  * Distributor Config types made publicly accessible for configuration/testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->